### PR TITLE
add: 忽略 clangd 缓存文件

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .xmake
 build
 .vscode
+
+# ignore clangd toolchains
+.cache
+compile_commands.json


### PR DESCRIPTION
如果配置了clangd等工具链，会出现 `.cache` 以及 `compile_commands.json`, 文件繁多影响提交